### PR TITLE
Load preload.js

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain } = require('electron');
 const PubNub = require('pubnub');
 const { v4: uuidv4 } = require('uuid'); // Import the uuid library
+const path = require('path');
 
 const publishKey = 'pub-c-d8e5e5ee-1234-47e1-8986-4fb7f1a7e6f1';
 const subscribeKey = 'sub-c-cd13ae42-d352-4daf-927e-cead3be9595d';
@@ -19,6 +20,11 @@ app.on('ready', () => {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
+    webPreferences: {
+      //nodeIntegration: true,
+      //contextIsolation: false,
+      preload: path.join(__dirname, 'preload.js')
+    }
   });
 
   mainWindow.loadFile('index.html');

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <title>Electron WebRTC App</title>
-  <script src="./preload.js" type="text/javascript" preload onload="window.nodeApi.ready();"></script>
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' nonce-string;">
 </head>
 


### PR DESCRIPTION
These changes properly load preload.js

BEFORE
Preload.js was loaded as a script in the html file

AFTER
Preload.js is preloaded in the browser window by the electron framework
